### PR TITLE
Refactor/cascade class name

### DIFF
--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -11,6 +11,7 @@ import {
 
 function StringField(props) {
   const {
+    className,
     schema,
     name,
     uiSchema,
@@ -38,6 +39,7 @@ function StringField(props) {
   return <Widget
     {...inputProps}
     options={{...options, enumOptions}}
+    className={className}
     schema={schema}
     id={idSchema && idSchema.$id}
     label={title === undefined ? name : title}

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -32,6 +32,7 @@ class BaseInput extends React.Component {
       schema,   // eslint-disable-line
       formContext,  // eslint-disable-line
       registry, // eslint-disable-line
+      className,
       ...inputProps
     } = this.props;
     const {delayedValue} = this.state;
@@ -39,7 +40,7 @@ class BaseInput extends React.Component {
     return (
       <input
       {...inputProps}
-      className="form-control"
+      className={`form-control ${className}`}
       readOnly={readonly}
       autoFocus={autofocus}
       value={typeof delayedValue === "undefined" ? "" : delayedValue}

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -19,6 +19,7 @@ function processValue({type, items}, value) {
 }
 
 function SelectWidget({
+  className,
   schema,
   id,
   options,
@@ -35,7 +36,7 @@ function SelectWidget({
     <select
       id={id}
       multiple={multiple}
-      className="form-control"
+      className={`form-control ${className}`}
       value={value}
       required={required}
       disabled={disabled}


### PR DESCRIPTION
### Reasons for making this change

New Feature: Allows developers to include their class names into select and base input widgets. Simply pass a `className` prop to the `SelectWidget` or `BaseInput` components.

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
