### PR TITLE
Set empty string to undefined

### DIFF
--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -44,7 +44,11 @@ function StringField(props) {
     id={idSchema && idSchema.$id}
     label={title === undefined ? name : title}
     value={defaultFieldValue(formData, schema)}
-    onChange={onChange}
+    onChange={(value) => {
+      const stringValue = value.length > 0 ? value : undefined;
+
+      onChange(stringValue);
+    }}
     required={required}
     disabled={disabled}
     readonly={readonly}


### PR DESCRIPTION
### Reasons for making this change

When the user removed the string value, it would set the value to an empty string which would pass validation.