### PR TITLE
Fix/empty string set to undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bsonschema-form",
-  "version": "0.42.29",
+  "version": "0.42.30",
   "description": "A simple React component capable of building HTML forms out of a JSON schema.",
   "scripts": {
     "build:readme": "toctoc README.md -w",

--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -44,9 +44,7 @@ function StringField(props) {
     id={idSchema && idSchema.$id}
     label={title === undefined ? name : title}
     value={defaultFieldValue(formData, schema)}
-    onChange={(value) => {
-      onChange((typeof value === 'string' && value.length > 0) ? value : undefined);
-    }}
+    onChange={onChange}
     required={required}
     disabled={disabled}
     readonly={readonly}


### PR DESCRIPTION
### Reasons for making this change

Data for attribute is being set to undefined when string is empty. This is causing the attribute not be unset when saved. 

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
