### PR TITLE
bugfix: Guard against ui:options being undefined (v0.43.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bsonschema-form",
-  "version": "0.43.5",
+  "version": "0.43.6",
   "description": "A simple React component capable of building HTML forms out of a JSON schema.",
   "scripts": {
     "build:readme": "toctoc README.md -w",

--- a/src/components/fields/BsonNumberFieldHOC.js
+++ b/src/components/fields/BsonNumberFieldHOC.js
@@ -14,7 +14,7 @@ function toString (value) {
 }
 
 function BsonNumberField ({ formData, onChange, stringToBsonNumber, ...other }) {
-  const options = other.uiSchema['ui:options']
+  const options = other.uiSchema['ui:options'] || {}
   // NOTE: formData is string, so when it's false, it must be empty string or undefined
   const parse = (value) => {
     return typeof value === 'string' ? stringToBsonNumber(value, options) : value


### PR DESCRIPTION
### Reasons for making this change

Was receiving undefined for ui:options. This defaults ui:options to an empty object when undefined

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
