### PR TITLE
SelectWidget 

### DIFF
--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -18,6 +18,10 @@ function processValue({type, items}, value) {
   return value;
 }
 
+function renderEmptyOption() {
+  return <option value="" />;
+}
+
 function SelectWidget({
   className='form-control',
   schema,
@@ -32,6 +36,10 @@ function SelectWidget({
   onChange
 }) {
   const {enumOptions} = options;
+
+  const emptyOption = !multiple && (!schema.default || schema.default.length === 0)
+    ? renderEmptyOption()
+    : null;
 
   return (
     <select
@@ -53,6 +61,7 @@ function SelectWidget({
         }
         onChange(processValue(schema, newValue));
       }}>
+      {emptyOption}
       {enumOptions.map(({value, label}, i) => {
          return <option key={i} value={value}>{label}</option>;
       })

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -32,6 +32,7 @@ function SelectWidget({
   onChange
 }) {
   const {enumOptions} = options;
+
   return (
     <select
       id={id}
@@ -51,9 +52,10 @@ function SelectWidget({
           newValue = event.target.value;
         }
         onChange(processValue(schema, newValue));
-      }}>{
-      enumOptions.map(({value, label}, i) => {
-        return <option key={i} value={value}>{label}</option>;
+      }}>
+      {!multiple && !schema.default && <option value="" />}
+      {enumOptions.map(({value, label}, i) => {
+         return <option key={i} value={value}>{label}</option>;
       })
     }</select>
   );

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -53,7 +53,6 @@ function SelectWidget({
         }
         onChange(processValue(schema, newValue));
       }}>
-      {!multiple && !schema.default && <option value="" />}
       {enumOptions.map(({value, label}, i) => {
          return <option key={i} value={value}>{label}</option>;
       })

--- a/src/utils.js
+++ b/src/utils.js
@@ -174,9 +174,6 @@ function computeDefaults(schema, parentDefaults, definitions={}) {
   } else if ("default" in schema) {
     // Use schema defaults for this node.
     defaults = schema.default;
-  } else if ("enum" in schema && Array.isArray(schema.enum)) {
-    // For enum with no defined default, select the first entry.
-    defaults = schema.enum[0];
   } else if ("$ref" in schema) {
     // Use referenced schema defaults for this node.
     const refSchema = findSchemaDefinition(schema.$ref, definitions);


### PR DESCRIPTION
* If no default was provided to SelectWidget or default was an empty string, render empty option
* When computing defaults for bson form check the following conditions:
  * That the default is not an empty string
  * If the schema type is an enum
* If the schema type is an enum, return the default value as the type (int, double, long) or as the original value
