### PR TITLE
Convert default enum value to BSON object

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "bson": "^0.5.5",
-    "bsonschema": "1.1.4",
+    "bsonschema": "1.1.5",
     "moment": "^2.15.0",
     "react-datetime": "^2.8.8",
     "lodash.topath": "^4.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bsonschema-form",
-  "version": "0.43.6",
+  "version": "0.43.7",
   "description": "A simple React component capable of building HTML forms out of a JSON schema.",
   "scripts": {
     "build:readme": "toctoc README.md -w",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 import React from "react";
 import "setimmediate";
+import { Int32, Long, Double } from 'bson';
 
 
 const widgetMap = {
@@ -176,7 +177,19 @@ function computeDefaults(schema, parentDefaults, definitions={}) {
     defaults = schema.default;
   } else if ("enum" in schema && Array.isArray(schema.enum)) {
     // For enum with no defined default, select the first entry.
-    defaults = schema.enum[0];
+    switch(schema.type) {
+      case 'int':
+        defaults = new Int32(schema.enum[0]);
+        break;
+      case 'long':
+        defaults = new Long(schema.enum[0]);
+        break;
+      case 'double':
+        defaults = new Double(schema.enum[0]);
+        break;
+      default:
+        defaults = schema.enum[0];
+    }
   } else if ("$ref" in schema) {
     // Use referenced schema defaults for this node.
     const refSchema = findSchemaDefinition(schema.$ref, definitions);

--- a/src/utils.js
+++ b/src/utils.js
@@ -258,11 +258,11 @@ function shouldSkip (v) {
 
 export function mergeObjects(obj1, obj2, concatArrays = false) {
   // NOTE: do not merge bson object types
-  if (shouldSkip(obj1)) {
-    return obj1;
-  }
   if (shouldSkip(obj2)) {
     return obj2;
+  }
+  if (shouldSkip(obj1)) {
+    return obj1;
   }
   // Recursively merge deeply nested objects.
   var acc = Object.assign({}, obj1); // Prevent mutation of source object.


### PR DESCRIPTION
### Reasons for making this change

Convert default enum value to BSON object. Also fixes a bug in mergeObjects where form data BSON objects were not overriding default BSON objects

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
